### PR TITLE
Fix `showarray`

### DIFF
--- a/src/sparsevec.jl
+++ b/src/sparsevec.jl
@@ -223,10 +223,10 @@ function Base.showarray(io::IO, x::GenericSparseVector;
         if k < half_screen_rows || k > nnz(x)-half_screen_rows
             print(io, "\t", '[', rpad(x.nzind[k], pad), "]  =  ")
             showcompact(io, x.nzval[k])
-            print(io, "\n")
         elseif k == half_screen_rows
             print(io, sep, '\u22ee')
         end
+        print(io, "\n")
         k += 1
     end
 end

--- a/src/sparsevec.jl
+++ b/src/sparsevec.jl
@@ -218,7 +218,7 @@ function Base.showarray(io::IO, x::GenericSparseVector;
     end
     pad = ndigits(x.n)
     k = 0
-
+    sep = "\n\t"
     for k = 1:length(x.nzind)
         if k < half_screen_rows || k > nnz(x)-half_screen_rows
             print(io, "\t", '[', rpad(x.nzind[k], pad), "]  =  ")


### PR DESCRIPTION
The `showarray` method errors when `k == half_screen_rows` due to missing definition of `sep`, which is now `sep = "\n\t"`.
