### PR TITLE
Remove erroneous SparseVector early exit

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -110,7 +110,6 @@ function _binarymap{Tx,Ty}(f::BinaryOp,
     ynzval = nonzeros(y)
     mx = length(xnzind)
     my = length(ynzind)
-    (mx == 0 || my == 0) && return SparseVector(R, 0)
     cap = (mode == 0 ? min(mx, my) : mx + my)::Int
 
     rind = Array(Int, cap)

--- a/test/math.jl
+++ b/test/math.jl
@@ -170,3 +170,10 @@ let x = sparsevector(Float64, 8)
     @test maxabs(x) == 0.0
     @test minabs(x) == 0.0
 end
+
+# Issue https://github.com/JuliaLang/julia/issues/14046
+let s14046 = sprand(5, 1.0)
+    z = sparsevector(Float64, 5)
+    @test z + s14046 == s14046
+    @test 2*z == z + z == z
+end


### PR DESCRIPTION
There is an optimization available here, but this isn't quite it. Ref JuliaLang/julia#14442.
