### PR TITLE
Fix 0.4 deprecated types

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -35,5 +35,5 @@ _dot(x::Number, y::Number) = conj(x) * y
 _dot(x::Real, y::Real) = x * y
 call(::DotFun, x::Number, y::Number) = _dot(x, y)
 
-typealias UnaryOp Union(Function, Func{1})
-typealias BinaryOp Union(Function, Func{2})
+@compat typealias UnaryOp Union{Function, Func{1}}
+@compat typealias BinaryOp Union{Function, Func{2}}

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -158,7 +158,7 @@ function reinterpret{T,Tv}(::Type{T}, x::AbstractSparseVector{Tv})
     SparseVector(length(x), copy(nonzeroinds(x)), reinterpret(T, nonzeros(x)))
 end
 
-float{Tv<:FloatingPoint}(x::AbstractSparseVector{Tv}) = x
+@compat float{Tv<:AbstractFloat}(x::AbstractSparseVector{Tv}) = x
 float(x::AbstractSparseVector) =
     SparseVector(length(x), copy(nonzeroinds(x)), float(nonzeros(x)))
 

--- a/src/sparsevec.jl
+++ b/src/sparsevec.jl
@@ -274,18 +274,18 @@ convert{Tv,TvS,TiS}(::Type{SparseVector{Tv}}, s::SparseVector{TvS,TiS}) =
 
 ### Rand Construction
 
-function sprand{T}(n::Integer, p::FloatingPoint, rfn::Function, ::Type{T})
+@compat function sprand{T}(n::Integer, p::AbstractFloat, rfn::Function, ::Type{T})
     I = randsubseq(1:convert(Int, n), p)
     V = rfn(T, length(I))
     SparseVector(n, I, V)
 end
 
-function sprand(n::Integer, p::FloatingPoint, rfn::Function)
+@compat function sprand(n::Integer, p::AbstractFloat, rfn::Function)
     I = randsubseq(1:convert(Int, n), p)
     V = rfn(length(I))
     SparseVector(n, I, V)
 end
 
-sprand{T}(n::Integer, p::FloatingPoint, ::Type{T}) = sprand(n, p, rand, T)
-sprand(n::Integer, p::FloatingPoint) = sprand(n, p, rand)
-sprandn(n::Integer, p::FloatingPoint) = sprand(n, p, randn)
+@compat sprand{T}(n::Integer, p::AbstractFloat, ::Type{T}) = sprand(n, p, rand, T)
+@compat sprand(n::Integer, p::AbstractFloat) = sprand(n, p, rand)
+@compat sprandn(n::Integer, p::AbstractFloat) = sprand(n, p, randn)


### PR DESCRIPTION
Some quality of life fixes on 0.4 until 0.5 obsoletes this package. I think an owner might have to tag a new release on METADATA.jl as well.
